### PR TITLE
removed std::experimental::filesystem::v1 usage

### DIFF
--- a/vive-osc-sender/LighthouseTracking.cpp
+++ b/vive-osc-sender/LighthouseTracking.cpp
@@ -7,7 +7,6 @@
 #include "stdafx.h"
 #include "LighthouseTracking.h"
 #include <filesystem>
-using namespace std::experimental::filesystem::v1;
 
 // Destructor
 LighthouseTracking::~LighthouseTracking() {


### PR DESCRIPTION
Using namespace `std::experimental::filesystem::v1 usage` with VS2019 (even with ISO C++17 Standard (/std:c++17)  enabled) caused compiler errors. Removing it resolved the problem